### PR TITLE
package.json: Make some updates to fix a variety of small issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,20 @@
 {
   "name": "transitTracks",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "A public transit tracking API",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codeforhuntsville/transitTracks"
+  },
   "main": "hsvtt.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node hsvtt.js",
+    "lint": "eslint ."
   },
   "dependencies": {
     "body-parser": "^1.3.5",
+    "coffee-script": "^1.10.0",
+    "connect": "^3.4.1",
     "cron": "^1.1.0",
     "ejs": "^2.3.1",
     "express-session": "^1.11.3",
@@ -27,5 +34,5 @@
     "heroku",
     "express"
   ],
-  "license": "Restricted"
+  "license": "MIT"
 }


### PR DESCRIPTION
This patch fixes a variety of small issues in the package.json file. This
includes:
- The minor version has been bumped to 0.0.1 (simply because the site is live)
- The repository for the project has been specified
- The NPM script for 'start' has been updated to accurately reflect the file
  that should be invoked with node
- A new NPM script for linting with eslint has been added. Note that this
  patch does not provide an eslintrc file; that will be done in a separate
  patch
- Several missing project dependencies have been added

Finally, and most importantly, this patch picks the Open Source license for
this project. "Restricted", unfortunately, doesn't mean much as it does not
define what those restrictions are.

I've gone ahead and nominated the MIT License for this project, as it seems to
fit well with the spirit of Code for the South, as well as the intentions of
this project. If a different open source license feels like it is more
appropriate, a code review discussion should occur.
